### PR TITLE
Severityの文字を修正

### DIFF
--- a/inspector/inspector.py
+++ b/inspector/inspector.py
@@ -29,7 +29,7 @@ def format_message(data):
                         'title': 'Severity',
                         'value': data.get('severity'),
                         'short': True
-                    }, 
+                    },
                     {
                         'title': 'Timestamp',
                         'value': data.get('createdAt').strftime("%m/%d/%Y, %H:%M:%S%Z"),
@@ -97,7 +97,7 @@ def get_finding_arn(event):
 def lambda_handler(event, context):
     webhook_urls = os.environ['WEBHOOK_URLS']
     finding = get_finding_detail( get_finding_arn(event) )
-    if not finding.get('severity') in ['HIGH', 'Medium']:
+    if not finding.get('severity') in ['High', 'Medium']:
       return 'ignore finding of less than Medium'
     payload = format_message(finding)
     responses = []


### PR DESCRIPTION
## Severityの`HIGH`を修正

Highレベルでも通知を飛ばす場合は、以下のようにH以外は小文字で記述する必要がありました:smiley:

![スクリーンショット 2020-02-13 15 02 27](https://user-images.githubusercontent.com/24252885/74406381-d9784e80-4e72-11ea-8881-e9da80807281.png)

